### PR TITLE
master-qa-25355

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -4174,7 +4174,23 @@ go]]></replacevalue>
 
 						<dirname file="${osgi.module.bnd.file}" property="osgi.module.dir" />
 
-						<gradle-execute dir="${osgi.module.dir}" task="deploy" />
+						<if>
+							<contains string="${osgi.module.dir}" substring="modules" />
+							<then>
+								<gradle-execute dir="${osgi.module.dir}" task="deploy" />
+							</then>
+							<else>
+								<var name="osgi.module.dir" unset="true" />
+
+								<dirset dir="${project.dir}/modules" id="dir.id">
+									<include name="**/@{osgi.module}" />
+								</dirset>
+
+								<property name="osgi.module.dir" refid="dir.id" />
+
+								<gradle-execute dir="modules/${osgi.module.dir}" task="deploy" />
+							</else>
+						</if>
 					</sequential>
 				</for>
 			</then>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/webform/pgwebform/PGWebform.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/webform/pgwebform/PGWebform.testcase
@@ -1,6 +1,6 @@
 <definition component-name="portal-web-forms-and-data-lists">
 	<property name="portal.release" value="true" />
-	<property name="portlet.plugins.includes" value="web-form-portlet" />
+	<property name="osgi.modules.includes" value="web-form-portlet" />
 	<property name="testray.main.component.name" value="Web Form" />
 
 	<var name="pageName" value="Web Form Test Page" />


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-25355

My plugin (web form) got moved to the modules directory in portal source. I now have to deploy the web form module in my tests. The problem I ran into is that the deploy-osgi-module command only supports modules that have a bnd.bnd file in their root directory. The reason the task uses the bnd.bnd is because there can be duplicate directory names and it makes it easier to find the correct one. What I did was add a conditional so if the task cannot find the bnd file for the module it just tries to find the directory. I am open to a better way of doing this if you have any ideas