### PR TITLE
master-qa-27224

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/functions/Type.function
+++ b/portal-web/test/functional/com/liferay/portalweb/functions/Type.function
@@ -6,10 +6,6 @@
 
 		<execute selenium="mouseOver" />
 
-		<execute argument2="" selenium="type" />
-
-		<execute argument1="1000" selenium="pause" />
-
 		<execute selenium="clickAt" />
 
 		<execute argument1="1000" selenium="pause" />
@@ -33,10 +29,6 @@
 		<execute selenium="waitForVisible" />
 
 		<execute selenium="mouseOver" />
-
-		<execute argument2="" selenium="type" />
-
-		<execute argument1="1000" selenium="pause" />
 
 		<execute selenium="clickAt" />
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/BlogsEntry.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/BlogsEntry.macro
@@ -105,7 +105,7 @@
 
 	<command name="addTagList">
 		<for list="${tagNameList}" param="tagName">
-			<execute function="Type#clickAtSendKeys" locator1="AssetCategorization#CATEGORIES_SEARCH_FIELD" value1="${tagName}" />
+			<execute function="Type#clickAtType" locator1="AssetCategorization#CATEGORIES_SEARCH_FIELD" value1="${tagName}" />
 
 			<execute function="AssertClick" locator1="Button#ADD_TAGS" value1="Add" />
 		</for>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/CalendarEvent.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/CalendarEvent.macro
@@ -1408,7 +1408,7 @@
 			<then>
 				<execute function="Click" locator1="CalendarEditEvent#REPEAT_ENDS_ON_RADIO" />
 
-				<execute function="Type#clickAtSendKeys" locator1="CalendarEditEvent#REPEAT_ENDS_ON_DATE_FIELD" value1="${endOnDate}" />
+				<execute function="Type#clickAtType" locator1="CalendarEditEvent#REPEAT_ENDS_ON_DATE_FIELD" value1="${endOnDate}" />
 			</then>
 		</if>
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/DDLDataDefinition.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DDLDataDefinition.macro
@@ -23,14 +23,14 @@
 		</if>
 
 		<execute function="Click" locator1="Button#PLUS" />
-		<execute function="Type#clickAtSendKeys" locator1="DDMEditStructure#NAME_FIELD" value1="${ddlDataDefinitionName}" />
+		<execute function="Type#clickAtType" locator1="DDMEditStructure#NAME_FIELD" value1="${ddlDataDefinitionName}" />
 
 		<execute macro="DDLDataDefinition#_showDetails" />
 
 		<if>
 			<isset var="ddlDataDefinitionDescription" />
 			<then>
-				<execute function="Type#clickAtSendKeys" locator1="DDMEditStructure#DETAILS_DESCRIPTION_FIELD" value1="${ddlDataDefinitionDescription}" />
+				<execute function="Type#clickAtType" locator1="DDMEditStructure#DETAILS_DESCRIPTION_FIELD" value1="${ddlDataDefinitionDescription}" />
 			</then>
 		</if>
 	</command>
@@ -167,11 +167,11 @@
 		<execute function="Click#waitForMenuToggleJSClick" locator1="DDMSelectStructure#DDM_STRUCTURE_ELLIPSIS_1" />
 		<execute function="AssertClick" locator1="MenuItem#EDIT" value1="Edit" />
 
-		<execute function="Type#clickAtSendKeys" locator1="TextInput#NAME" value1="${ddlDataDefinitionNameEdit}" />
+		<execute function="Type#clickAtType" locator1="TextInput#NAME" value1="${ddlDataDefinitionNameEdit}" />
 
 		<execute macro="DDLDataDefinition#_showDetails" />
 
-		<execute function="Type#clickAtSendKeys" locator1="DDMEditStructure#DETAILS_DESCRIPTION_FIELD" value1="${ddlDataDefinitionDescriptionEdit}" />
+		<execute function="Type#clickAtType" locator1="DDMEditStructure#DETAILS_DESCRIPTION_FIELD" value1="${ddlDataDefinitionDescriptionEdit}" />
 	</command>
 
 	<command name="editPermissionsCP">

--- a/portal-web/test/functional/com/liferay/portalweb/macros/DDLList.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DDLList.macro
@@ -6,12 +6,12 @@
 	<command name="addCP">
 		<execute function="Click" locator1="Button#PLUS" />
 
-		<execute function="Type#clickAtSendKeys" locator1="TextInput#NAME" value1="${ddlListName}" />
+		<execute function="Type#clickAtType" locator1="TextInput#NAME" value1="${ddlListName}" />
 
 		<if>
 			<isset var="ddlListDescription" />
 			<then>
-				<execute function="Type#clickAtSendKeys" locator1="TextArea#DESCRIPTION" value1="${ddlListDescription}" />
+				<execute function="Type#clickAtType" locator1="TextArea#DESCRIPTION" value1="${ddlListDescription}" />
 			</then>
 		</if>
 
@@ -98,12 +98,12 @@
 
 		<execute function="AssertClick" locator1="MenuItem#EDIT" value1="Edit" />
 
-		<execute function="Type#clickAtSendKeys" locator1="TextInput#NAME" value1="${ddlListNameEdit}" />
+		<execute function="Type#clickAtType" locator1="TextInput#NAME" value1="${ddlListNameEdit}" />
 
 		<if>
 			<isset var="ddlListDescriptionEdit" />
 			<then>
-				<execute function="Type#clickAtSendKeys" locator1="TextArea#DESCRIPTION" value1="${ddlListDescriptionEdit}" />
+				<execute function="Type#clickAtType" locator1="TextArea#DESCRIPTION" value1="${ddlListDescriptionEdit}" />
 			</then>
 		</if>
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/DDLTemplate.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DDLTemplate.macro
@@ -111,7 +111,7 @@
 
 		<execute function="AssertClick" locator1="MenuItem#ADD_FORM_TEMPLATE" value1="Add Form Template" />
 
-		<execute function="Type#clickAtSendKeys" locator1="TextInput#NAME" value1="${ddlFormTemplateName}" />
+		<execute function="Type#clickAtType" locator1="TextInput#NAME" value1="${ddlFormTemplateName}" />
 	</command>
 
 	<command name="addFormTemplateViaBackButton">
@@ -123,7 +123,7 @@
 
 		<execute function="AssertClick" locator1="MenuItem#ADD_FORM_TEMPLATE" value1="Add Form Template" />
 
-		<execute function="Type#clickAtSendKeys" locator1="TextInput#NAME" value1="${ddlFormTemplateName}" />
+		<execute function="Type#clickAtType" locator1="TextInput#NAME" value1="${ddlFormTemplateName}" />
 	</command>
 
 	<command name="addFormTemplateViaDDLDisplayPG">

--- a/portal-web/test/functional/com/liferay/portalweb/macros/DMDocumentType.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DMDocumentType.macro
@@ -85,7 +85,7 @@
 		<if>
 			<isset var="dmDocumentTypeNameEdit" />
 			<then>
-				<execute function="Type#clickAtSendKeys" locator1="DocumentsAndMediaEditDocumentType#NAME_FIELD" value1="${dmDocumentTypeNameEdit}"  />
+				<execute function="Type#clickAtType" locator1="DocumentsAndMediaEditDocumentType#NAME_FIELD" value1="${dmDocumentTypeNameEdit}"  />
 			</then>
 		</if>
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/PortalSettings.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/PortalSettings.macro
@@ -266,7 +266,7 @@
 
 		<execute function="AssertClick" locator1="NavTab#DEFAULT_USER_ASSOCIATIONS" value1="Default User Associations" />
 
-		<execute function="Type#clickAtSendKeys" locator1="PortalSettingsUsers#DEFAULT_USER_ASSOCIATIONS_ROLES_FIELD" value1="${roleName}" />
+		<execute function="Type#clickAtType" locator1="PortalSettingsUsers#DEFAULT_USER_ASSOCIATIONS_ROLES_FIELD" value1="${roleName}" />
 	</command>
 
 	<command name="editConfigurationUsersDefaultUserAssociationsSitesCP">
@@ -600,7 +600,7 @@
 		</execute>
 
 		<execute function="AssertClick" locator1="NavTab#DEFAULT_USER_ASSOCIATIONS" value1="Default User Associations" />
-		<execute function="Type#clickAtSendKeys" locator1="PortalSettingsUsers#DEFAULT_USER_ASSOCIATIONS_ROLES_FIELD" value1="${roleName}" />
+		<execute function="Type#clickAtType" locator1="PortalSettingsUsers#DEFAULT_USER_ASSOCIATIONS_ROLES_FIELD" value1="${roleName}" />
 	</command>
 
 	<command name="viewConfigurationUsersDefaultUserAssociationsSitesCP">
@@ -649,7 +649,7 @@
 		<execute function="AssertTextEquals#assertPartialText" locator1="PortalSettingsUsers#DEFAULT_USER_ASSOCIATIONS_ORGANIZATION_SITES_HEADER" value1="Organization Sites" />
 		<execute function="AssertTextEquals" locator1="PortalSettingsUsers#DEFAULT_USER_ASSOCIATIONS_ORGANIZATION_SITES_FIELD" value1="" />
 		<execute function="AssertTextEquals#assertPartialText" locator1="PortalSettingsUsers#DEFAULT_USER_ASSOCIATIONS_ROLES_HEADER" value1="Roles" />
-		<execute function="Type#clickAtSendKeys" locator1="PortalSettingsUsers#DEFAULT_USER_ASSOCIATIONS_ROLES_FIELD" value1="Power User\nUser" />
+		<execute function="Type#clickAtType" locator1="PortalSettingsUsers#DEFAULT_USER_ASSOCIATIONS_ROLES_FIELD" value1="Power User\nUser" />
 		<execute function="AssertTextEquals#assertPartialText" locator1="PortalSettingsUsers#DEFAULT_USER_ASSOCIATIONS_USER_GROUPS_HEADER" value1="User Groups" />
 		<execute function="AssertTextEquals" locator1="PortalSettingsUsers#DEFAULT_USER_ASSOCIATIONS_USER_GROUPS_FIELD" value1="" />
 	</command>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/SiteTemplates.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/SiteTemplates.macro
@@ -92,7 +92,7 @@
 			</then>
 		</if>
 
-		<execute function="Type#clickAtSendKeys" locator1="TextInput#NAME" value1="${pageName}" />
+		<execute function="Type#clickAtType" locator1="TextInput#NAME" value1="${pageName}" />
 		<execute function="AssertClick" locator1="Button#ADD_PAGE_BTN" value1="Add Page" />
 	</command>
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/WebContent.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/WebContent.macro
@@ -137,7 +137,7 @@
 
 		<execute function="Uncheck" locator1="Checkbox#NEVER_EXPIRE" value1="Never Expire" />
 
-		<execute function="Type#clickAtSendKeys" locator1="TextInput#EXPIRATION_DATE" value1="${expirationDate}" />
+		<execute function="Type#clickAtType" locator1="TextInput#EXPIRATION_DATE" value1="${expirationDate}" />
 	</command>
 
 	<command name="addFailWithoutRequiredCategoryAssetTypeCP">
@@ -684,7 +684,7 @@
 		<for list="${tagNameList}" param="tagName">
 			<execute function="Click" locator1="AssetCategorization#TAGS_ADD_BUTTON" />
 
-			<execute function="Type#clickAtSendKeys" locator1="AssetCategorization#TAGS_FIELD" value1="${tagName}" />
+			<execute function="Type#clickAtType" locator1="AssetCategorization#TAGS_FIELD" value1="${tagName}" />
 		</for>
 
 		<execute function="Click" locator1="AssetCategorization#TAGS_ADD_BUTTON" />

--- a/portal-web/test/functional/com/liferay/portalweb/macros/WebContentDisplayPortlet.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/WebContentDisplayPortlet.macro
@@ -103,7 +103,7 @@
 
 		<execute function="SelectFrame" locator1="IFrame#MODAL_IFRAME" />
 
-		<execute function="Type#clickAtSendKeys" locator1="TextInput#NAME" value1="Template Edit" />
+		<execute function="Type#clickAtType" locator1="TextInput#NAME" value1="Template Edit" />
 
 		<if>
 			<isset var="templateScript" />

--- a/portal-web/test/functional/com/liferay/portalweb/macros/WebContentStructures.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/WebContentStructures.macro
@@ -50,7 +50,7 @@
 	</command>
 
 	<command name="addName">
-		<execute function="Type#clickAtSendKeys" locator1="TextInput#NAME" value1="${structureName}" />
+		<execute function="Type#clickAtType" locator1="TextInput#NAME" value1="${structureName}" />
 	</command>
 
 	<command name="addNullCP">

--- a/portal-web/test/functional/com/liferay/portalweb/macros/WebContentTemplates.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/WebContentTemplates.macro
@@ -4,7 +4,7 @@
 
 		<execute macro="LexiconEntry#gotoAdd" />
 
-		<execute function="Type#clickAtSendKeys" locator1="TextInput#NAME" value1="${templateName}" />
+		<execute function="Type#clickAtType" locator1="TextInput#NAME" value1="${templateName}" />
 
 		<execute macro="Panel#expandPanel">
 			<var name="panelHeading" value="Details" />
@@ -216,7 +216,7 @@
 
 		<execute function="Click" locator1="Translation#LOCALIZATION_NAME" />
 
-		<execute function="Type#clickAtSendKeys" locator1="TextInput#NAME" value1="${localization1Name}" />
+		<execute function="Type#clickAtType" locator1="TextInput#NAME" value1="${localization1Name}" />
 
 		<if>
 			<isset var="localization2NameKey" />
@@ -225,7 +225,7 @@
 
 				<execute function="Click" locator1="Translation#LOCALIZATION_NAME" />
 
-				<execute function="Type#clickAtSendKeys" locator1="TextInput#NAME" value1="${localization2Name}" />
+				<execute function="Type#clickAtType" locator1="TextInput#NAME" value1="${localization2Name}" />
 			</then>
 		</if>
 	</command>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/so/SOUserBar.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/so/SOUserBar.macro
@@ -125,7 +125,7 @@
 		<execute function="Click#pauseClickAt" locator1="SOUserBar#GO_TO_ADD_SITE_BUTTON" />
 
 		<execute function="SelectFrameTop" />
-		<execute function="Type#clickAtSendKeys" locator1="SOUserBarAddSite#NAME_FIELD" value1="${siteName}" />
+		<execute function="Type#clickAtType" locator1="SOUserBarAddSite#NAME_FIELD" value1="${siteName}" />
 		<execute function="Type" locator1="SOUserBarAddSite#DESCRIPTION_FIELD" value1="${siteDescription}" />
 		<execute function="Click" locator1="SOUserBarAddSite#NEXT_BUTTON" />
 
@@ -165,7 +165,7 @@
 		<if>
 			<condition function="IsElementPresent" locator1="SOUserBarAddSite#ERROR_MESSAGE" />
 			<then>
-				<execute function="Type#clickAtSendKeys" locator1="SOUserBarAddSite#NAME_FIELD" value1="${siteName}" />
+				<execute function="Type#clickAtType" locator1="SOUserBarAddSite#NAME_FIELD" value1="${siteName}" />
 				<execute function="Click" locator1="SOUserBarAddSite#SAVE_BUTTON" />
 			</then>
 		</if>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/dynamicdatalists/usecase/DynamicdatalistsUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/dynamicdatalists/usecase/DynamicdatalistsUsecase.testcase
@@ -74,7 +74,7 @@
 
 		<execute function="Click" locator1="Button#PLUS" />
 
-		<execute function="Type#clickAtSendKeys" locator1="TextInput#NAME" value1="${ddlListName}" />
+		<execute function="Type#clickAtType" locator1="TextInput#NAME" value1="${ddlListName}" />
 		<execute macro="Button#clickSave" />
 
 		<execute macro="Alert#viewRequestFailedToComplete" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduserso/administration/sosites/SOSites.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduserso/administration/sosites/SOSites.testcase
@@ -820,7 +820,7 @@
 
 		<execute function="SikuliAssertElementPresent" locator1="SOUserBar#SCREENSHOTS_USERBAR_GO_TO_MENU_ADD_SITE_SITE_NAME_REQUIRED_PNG" />
 
-		<execute function="Type#clickAtSendKeys" locator1="SOUserBarAddSite#NAME_FIELD" value1="${siteName}" />
+		<execute function="Type#clickAtType" locator1="SOUserBarAddSite#NAME_FIELD" value1="${siteName}" />
 		<execute function="Click" locator1="SOUserBarAddSite#SAVE_BUTTON" />
 		<execute function="AssertElementNotPresent#assertNotVisible" locator1="SOUserBarAddSite#SAVE_BUTTON" />
 	</command>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-27224

This removes the empty string type command used before `Type#clickAtSendKeys` and `Type#clickAtType` (for the first case, it defeats the purpose of `Type#typeAtSendKeys` since that one should emulate a real user's typing. It also clears up the naming scheme so that `clickAtSendKeys` and `clickAtType` really do clickAt and then type/sendKey.