### PR TITLE
LPS-80125 Pass in the anonymous user to the UADAnonymizer anonymize methods (rather than getting it in the method bodies)

### DIFF
--- a/modules/apps/foundation/user-associated-data/user-associated-data-test-util/src/main/java/com/liferay/user/associated/data/test/util/BaseUADAnonymizerTestCase.java
+++ b/modules/apps/foundation/user-associated-data/user-associated-data-test-util/src/main/java/com/liferay/user/associated/data/test/util/BaseUADAnonymizerTestCase.java
@@ -37,6 +37,7 @@ public abstract class BaseUADAnonymizerTestCase<T extends BaseModel> {
 
 	@Before
 	public void setUp() throws Exception {
+		_anonymousUser = UserTestUtil.addUser();
 		_uadAggregator = getUADAggregator();
 		_uadAnonymizer = getUADAnonymizer();
 		_user = UserTestUtil.addUser();
@@ -54,7 +55,7 @@ public abstract class BaseUADAnonymizerTestCase<T extends BaseModel> {
 		T baseModel = addBaseModel(TestPropsValues.getUserId());
 		T autoAnonymizedBaseModel = addBaseModel(_user.getUserId());
 
-		_uadAnonymizer.autoAnonymizeAll(_user.getUserId());
+		_uadAnonymizer.autoAnonymizeAll(_user.getUserId(), _anonymousUser);
 
 		long baseModelPK = getBaseModelPrimaryKey(baseModel);
 
@@ -70,7 +71,7 @@ public abstract class BaseUADAnonymizerTestCase<T extends BaseModel> {
 
 	@Test
 	public void testAutoAnonymizeAllWithNoBaseModel() throws Exception {
-		_uadAnonymizer.autoAnonymizeAll(_user.getUserId());
+		_uadAnonymizer.autoAnonymizeAll(_user.getUserId(), _anonymousUser);
 	}
 
 	@Test
@@ -166,12 +167,16 @@ public abstract class BaseUADAnonymizerTestCase<T extends BaseModel> {
 	private void _testAutoAnonymize(BaseModel baseModel) throws Exception {
 		List<T> baseModels = _uadAggregator.getAll(_user.getUserId());
 
-		_uadAnonymizer.autoAnonymize(baseModels.get(0), _user.getUserId());
+		_uadAnonymizer.autoAnonymize(
+			baseModels.get(0), _user.getUserId(), _anonymousUser);
 
 		long baseModelPK = getBaseModelPrimaryKey(baseModel);
 
 		Assert.assertTrue(isBaseModelAutoAnonymized(baseModelPK, _user));
 	}
+
+	@DeleteAfterTestRun
+	private User _anonymousUser;
 
 	private UADAggregator<T> _uadAggregator;
 	private UADAnonymizer<T> _uadAnonymizer;


### PR DESCRIPTION
This is an update for [LPS-80125](https://issues.liferay.com/browse/LPS-80125).<br><br>Hey Brian, this fixes the compile errors in upstream (see https://github.com/brianchandotcom/liferay-portal/pull/57692#issuecomment-384728317 for an example).<br><br>/cc @alee8888 @pei-jung @willnewbury