### PR TITLE
LPS-84549 Bulk Templates and Structures actions displays X icon instead of an encircled X icon for unrecoverable Delete functionality

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/display/context/AssetCategoriesDisplayContext.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/display/context/AssetCategoriesDisplayContext.java
@@ -227,7 +227,7 @@ public class AssetCategoriesDisplayContext {
 					dropdownItem -> {
 						dropdownItem.putData(
 							"action", "deleteSelectedCategories");
-						dropdownItem.setIcon("trash");
+						dropdownItem.setIcon("times-circle");
 						dropdownItem.setLabel(
 							LanguageUtil.get(_request, "delete"));
 						dropdownItem.setQuickAction(true);
@@ -653,7 +653,7 @@ public class AssetCategoriesDisplayContext {
 					dropdownItem -> {
 						dropdownItem.putData(
 							"action", "deleteSelectedVocabularies");
-						dropdownItem.setIcon("trash");
+						dropdownItem.setIcon("times-circle");
 						dropdownItem.setLabel(
 							LanguageUtil.get(_request, "delete"));
 						dropdownItem.setQuickAction(true);

--- a/modules/apps/asset/asset-tags-admin-web/src/main/java/com/liferay/asset/tags/admin/web/internal/display/context/AssetTagsDisplayContext.java
+++ b/modules/apps/asset/asset-tags-admin-web/src/main/java/com/liferay/asset/tags/admin/web/internal/display/context/AssetTagsDisplayContext.java
@@ -89,7 +89,7 @@ public class AssetTagsDisplayContext {
 				add(
 					dropdownItem -> {
 						dropdownItem.putData("action", "deleteTags");
-						dropdownItem.setIcon("trash");
+						dropdownItem.setIcon("times-circle");
 						dropdownItem.setLabel(
 							LanguageUtil.get(_request, "delete"));
 						dropdownItem.setQuickAction(true);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/display/context/DDMDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/display/context/DDMDisplayContext.java
@@ -157,7 +157,7 @@ public class DDMDisplayContext {
 				add(
 					dropdownItem -> {
 						dropdownItem.putData("action", action);
-						dropdownItem.setIcon("times");
+						dropdownItem.setIcon("times-circle");
 						dropdownItem.setLabel(
 							LanguageUtil.get(
 								_ddmWebRequestHelper.getRequest(), "delete"));

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentDisplayContext.java
@@ -349,7 +349,7 @@ public class FragmentDisplayContext {
 						dropdownItem -> {
 							dropdownItem.putData(
 								"action", "deleteSelectedFragmentEntries");
-							dropdownItem.setIcon("trash");
+							dropdownItem.setIcon("times-circle");
 							dropdownItem.setLabel(
 								LanguageUtil.get(_request, "delete"));
 							dropdownItem.setQuickAction(true);

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/DisplayPageDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/DisplayPageDisplayContext.java
@@ -75,7 +75,7 @@ public class DisplayPageDisplayContext {
 					dropdownItem -> {
 						dropdownItem.putData(
 							"action", "deleteSelectedDisplayPages");
-						dropdownItem.setIcon("trash");
+						dropdownItem.setIcon("times-circle");
 						dropdownItem.setLabel(
 							LanguageUtil.get(_request, "delete"));
 						dropdownItem.setQuickAction(true);

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutPageTemplateDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutPageTemplateDisplayContext.java
@@ -93,7 +93,7 @@ public class LayoutPageTemplateDisplayContext {
 					dropdownItem -> {
 						dropdownItem.putData(
 							"action", "deleteLayoutPageTemplateEntries");
-						dropdownItem.setIcon("trash");
+						dropdownItem.setIcon("times-circle");
 						dropdownItem.setLabel(
 							LanguageUtil.get(_request, "delete"));
 						dropdownItem.setQuickAction(true);

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutPrototypeDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutPrototypeDisplayContext.java
@@ -63,7 +63,7 @@ public class LayoutPrototypeDisplayContext {
 					dropdownItem -> {
 						dropdownItem.putData(
 							"action", "deleteSelectedLayoutPrototypes");
-						dropdownItem.setIcon("trash");
+						dropdownItem.setIcon("times-circle");
 						dropdownItem.setLabel(
 							LanguageUtil.get(_request, "delete"));
 						dropdownItem.setQuickAction(true);

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
@@ -113,7 +113,7 @@ public class LayoutsAdminDisplayContext {
 				add(
 					dropdownItem -> {
 						dropdownItem.putData("action", "deleteSelectedPages");
-						dropdownItem.setIcon("trash");
+						dropdownItem.setIcon("times-circle");
 						dropdownItem.setLabel(
 							LanguageUtil.get(_request, "delete"));
 						dropdownItem.setQuickAction(true);

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/OrphanPortletsDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/OrphanPortletsDisplayContext.java
@@ -67,7 +67,7 @@ public class OrphanPortletsDisplayContext {
 				add(
 					dropdownItem -> {
 						dropdownItem.putData("action", "deleteOrphanPortlets");
-						dropdownItem.setIcon("trash");
+						dropdownItem.setIcon("times-circle");
 						dropdownItem.setLabel(
 							LanguageUtil.get(_request, "delete"));
 						dropdownItem.setQuickAction(true);

--- a/modules/apps/layout/layout-set-prototype-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/layout/layout-set-prototype-web/src/main/resources/META-INF/resources/view.jsp
@@ -74,7 +74,7 @@
 	<liferay-frontend:management-bar-action-buttons>
 		<liferay-frontend:management-bar-button
 			href="javascript:;"
-			icon="trash"
+			icon="times-circle"
 			id="deleteSelectedLayoutSetPrototypes"
 			label="delete"
 		/>

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/java/com/liferay/site/navigation/admin/web/internal/display/context/SiteNavigationAdminDisplayContext.java
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/java/com/liferay/site/navigation/admin/web/internal/display/context/SiteNavigationAdminDisplayContext.java
@@ -81,7 +81,7 @@ public class SiteNavigationAdminDisplayContext {
 					dropdownItem -> {
 						dropdownItem.putData(
 							"action", "deleteSelectedSiteNavigationMenus");
-						dropdownItem.setIcon("trash");
+						dropdownItem.setIcon("times-circle");
 						dropdownItem.setLabel(
 							LanguageUtil.get(_request, "delete"));
 						dropdownItem.setQuickAction(true);

--- a/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/display/context/SiteAdminDisplayContext.java
+++ b/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/display/context/SiteAdminDisplayContext.java
@@ -99,7 +99,7 @@ public class SiteAdminDisplayContext {
 				add(
 					dropdownItem -> {
 						dropdownItem.putData("action", "deleteSites");
-						dropdownItem.setIcon("trash");
+						dropdownItem.setIcon("times-circle");
 						dropdownItem.setLabel(
 							LanguageUtil.get(_request, "delete"));
 						dropdownItem.setQuickAction(true);

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/OrganizationsDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/OrganizationsDisplayContext.java
@@ -68,7 +68,7 @@ public class OrganizationsDisplayContext {
 					dropdownItem -> {
 						dropdownItem.putData(
 							"action", "deleteSelectedOrganizations");
-						dropdownItem.setIcon("trash");
+						dropdownItem.setIcon("times-circle");
 						dropdownItem.setLabel(
 							LanguageUtil.get(_request, "delete"));
 						dropdownItem.setQuickAction(true);

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/UserGroupsDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/UserGroupsDisplayContext.java
@@ -77,7 +77,7 @@ public class UserGroupsDisplayContext {
 					dropdownItem -> {
 						dropdownItem.putData(
 							"action", "deleteSelectedUserGroups");
-						dropdownItem.setIcon("trash");
+						dropdownItem.setIcon("times-circle");
 						dropdownItem.setLabel(
 							LanguageUtil.get(_request, "delete"));
 						dropdownItem.setQuickAction(true);

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/UsersDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/UsersDisplayContext.java
@@ -75,7 +75,7 @@ public class UsersDisplayContext {
 				add(
 					dropdownItem -> {
 						dropdownItem.putData("action", "deleteSelectedUsers");
-						dropdownItem.setIcon("trash");
+						dropdownItem.setIcon("times-circle");
 						dropdownItem.setLabel(
 							LanguageUtil.get(_request, "delete"));
 						dropdownItem.setQuickAction(true);

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/organization_action.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/organization_action.jsp
@@ -30,7 +30,7 @@ Organization organization = (Organization)row.getObject();
 	</portlet:actionURL>
 
 	<liferay-ui:icon-delete
-		icon="trash"
+		icon="times-circle"
 		linkCssClass="icon-monospaced text-default"
 		message="remove-membership"
 		showIcon="<%= true %>"

--- a/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/display/context/EditSiteTeamAssignmentsUserGroupsDisplayContext.java
+++ b/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/display/context/EditSiteTeamAssignmentsUserGroupsDisplayContext.java
@@ -68,7 +68,7 @@ public class EditSiteTeamAssignmentsUserGroupsDisplayContext
 				add(
 					dropdownItem -> {
 						dropdownItem.putData("action", "deleteUserGroups");
-						dropdownItem.setIcon("trash");
+						dropdownItem.setIcon("times-circle");
 						dropdownItem.setLabel(
 							LanguageUtil.get(request, "delete"));
 						dropdownItem.setQuickAction(true);

--- a/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/display/context/EditSiteTeamAssignmentsUsersDisplayContext.java
+++ b/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/display/context/EditSiteTeamAssignmentsUsersDisplayContext.java
@@ -67,7 +67,7 @@ public class EditSiteTeamAssignmentsUsersDisplayContext
 				add(
 					dropdownItem -> {
 						dropdownItem.putData("action", "deleteUsers");
-						dropdownItem.setIcon("trash");
+						dropdownItem.setIcon("times-circle");
 						dropdownItem.setLabel(
 							LanguageUtil.get(request, "delete"));
 						dropdownItem.setQuickAction(true);

--- a/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/display/context/SiteTeamsDisplayContext.java
+++ b/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/display/context/SiteTeamsDisplayContext.java
@@ -75,7 +75,7 @@ public class SiteTeamsDisplayContext {
 				add(
 					dropdownItem -> {
 						dropdownItem.putData("action", "deleteSelectedTeams");
-						dropdownItem.setIcon("trash");
+						dropdownItem.setIcon("times-circle");
 						dropdownItem.setLabel(
 							LanguageUtil.get(_request, "delete"));
 						dropdownItem.setQuickAction(true);

--- a/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/edit_team_assignments_user_groups_action.jsp
+++ b/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/edit_team_assignments_user_groups_action.jsp
@@ -31,7 +31,7 @@ UserGroup userGroup = (UserGroup)row.getObject();
 </portlet:actionURL>
 
 <liferay-ui:icon-delete
-	icon="trash"
+	icon="times-circle"
 	linkCssClass="icon-monospaced text-default"
 	message="delete"
 	showIcon="<%= true %>"

--- a/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/edit_team_assignments_users_action.jsp
+++ b/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/edit_team_assignments_users_action.jsp
@@ -31,7 +31,7 @@ User user2 = (User)row.getObject();
 </portlet:actionURL>
 
 <liferay-ui:icon-delete
-	icon="trash"
+	icon="times-circle"
 	linkCssClass="icon-monospaced text-default"
 	message="delete"
 	showIcon="<%= true %>"

--- a/modules/apps/trash/trash-web/src/main/java/com/liferay/trash/web/internal/display/context/TrashDisplayContext.java
+++ b/modules/apps/trash/trash-web/src/main/java/com/liferay/trash/web/internal/display/context/TrashDisplayContext.java
@@ -82,7 +82,7 @@ public class TrashDisplayContext {
 				add(
 					dropdownItem -> {
 						dropdownItem.putData("action", "deleteSelectedEntries");
-						dropdownItem.setIcon("trash");
+						dropdownItem.setIcon("times-circle");
 						dropdownItem.setLabel(
 							LanguageUtil.get(_request, "delete"));
 						dropdownItem.setQuickAction(true);


### PR DESCRIPTION
Hey @brianchiu, I prefer to send you this first, since it might break functional tests due to the change in the delete icon. The idea is to follow the patterns established by the lexicon team here: https://lexicondesign.io/docs/patterns/actionsDefinition.html 

cc:// @kyle-miho